### PR TITLE
FIX: Reports page - canvas size and reports cards

### DIFF
--- a/templates/web/popravito/reports/index.html
+++ b/templates/web/popravito/reports/index.html
@@ -72,17 +72,29 @@
         <div class="dashboard-sparklines">
             <div>
                 <div class="labelled-sparkline">
-                    <span class="label reports-seven-days-label" data-datasetindex="0"><strong style="color: #F4A140;">[% tprintf(nget("%s problem reported", "%s problems reported", last_seven_days.problems_total), decode(last_seven_reported) _ '</strong>') %]</span>
+                    <span 
+                      class="label reports-seven-days-label" 
+                      data-datasetindex="0">
+                    <strong>[% tprintf(nget("%s problem reported", "%s problems reported", last_seven_days.problems_total), decode(last_seven_reported) _ '</strong>') %]
+                  </span>
                 </div>
             </div>
             <div>
                 <div class="labelled-sparkline">
-                    <span class="label reports-seven-days-label" data-datasetindex="0"><strong style="color: #4FADED;">[% tprintf(nget("%s update on problems", "%s updates on problems", last_seven_days.updated_total), decode(last_seven_updated) _ '</strong>') %]</span>
+                    <span 
+                      class="label reports-seven-days-label" 
+                      data-datasetindex="0">
+                    <strong>[% tprintf(nget("%s update on problems", "%s updates on problems", last_seven_days.updated_total), decode(last_seven_updated) _ '</strong>') %]
+                  </span>
                 </div>
             </div>
             <div>
                 <div class="labelled-sparkline">
-                    <span class="label reports-seven-days-label" data-datasetindex="0"><strong style="color: #62B356;">[% tprintf(nget("%s problem marked as fixed", "%s problems marked as fixed", last_seven_days.fixed_total), decode(last_seven_fixed) _ '</strong>') %]</span>
+                    <span 
+                      class="label reports-seven-days-label" 
+                      data-datasetindex="0">
+                    <strong>[% tprintf(nget("%s problem marked as fixed", "%s problems marked as fixed", last_seven_days.fixed_total), decode(last_seven_fixed) _ '</strong>') %]
+                  </span>
                 </div>
             </div>
         </div>

--- a/web/cobrands/popravito/layout.scss
+++ b/web/cobrands/popravito/layout.scss
@@ -1132,31 +1132,40 @@ fieldset {
 
 .canvas-position {
     position: absolute;
+    max-width: 723px;
+    max-height: 361px;
 }
 
-.labelled-sparkline {
-    display: flex;
-    justify-content: center;
-    width: 80%;
-    margin: auto;
-}
+.dashboard-sparklines {
 
-.label .reports-seven-days-label {
-    display: flex;
-    flex-direction: column;
-    text-align: center;
-    background-color: gray;
-    width: fit-content;
-    padding: 4px 16px;
-    background-color: #FAFAFA;
-    margin-bottom: 1.5rem;
-    padding: 2rem 5rem 2rem 5rem;
-
-    strong {
-        font-size: 2.2rem;
-        color: #1D1C1C;
+    .labelled-sparkline {
+        display: flex;
+        justify-content: center;
+        width: 80%;
+        margin: auto;
+  
+        .label {
+            // display: flex;
+            // flex-direction: column;
+            text-align: center;
+            background-color: gray;
+            width: fit-content;
+            padding: 4px 16px;
+            background-color: #FAFAFA;
+            margin-bottom: 1.5rem;
+            padding: 2rem 5rem 2rem 5rem;
+            text-transform: uppercase;
+        
+            strong {
+                font-size: 2.2rem;
+                color: #1D1C1C;
+                display: block;
+                margin-bottom: 1rem;
+            }
+  
+        }
     }
-}
+  } 
 
 .dashboard-search {
     display: flex;


### PR DESCRIPTION
Please check the following:

- [ ] Whether this PR should include changes to any documentation, or the FAQ;
- [ ] All cobrand-specific commits start their commit message with the cobrand in square brackets;
- [ ] Is new functionality tested? CodeCov will warn you about the diff coverage, but won’t complain about e.g. new files;
- [ ] Are the changes tested for accessibility?
- [ ] Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

Please check the contributing docs, and describe your pull request here.
Screenshots or GIF animations (using e.g. LICEcap) may be helpful.

Please include any issues that are fixed, using "fixes" or "closes" so that
they are auto-closed when the PR is merged.

Thanks for contributing!
