### PR TITLE
Add top_banner functionality

### DIFF
--- a/templates/web/popravitodev/index.html
+++ b/templates/web/popravitodev/index.html
@@ -142,6 +142,7 @@
 
 [% INCLUDE 'footer.html' pagefooter = 'yes' %]
 
+<script src="/cobrands/[% c.cobrand.asset_moniker %]/front.js"></script>
 <script src="/cobrands/[% c.cobrand.asset_moniker %]/menu.js"></script>
 
 </body>

--- a/web/cobrands/popravitodev/front.js
+++ b/web/cobrands/popravitodev/front.js
@@ -1,0 +1,68 @@
+(function(){
+    if (!document.querySelector) { return; } // Ako nije podržan document.querySelector, prekini izvršavanje
+    if (navigator.userAgent.indexOf('Google Page Speed') !== -1) { return; } // Ako se koristi Google Page Speed, prekini izvršavanje
+    if (document.cookie.indexOf('has_seen_country_message') !== -1) { return; } // Ako je već postavljena cookie varijabla 'has_seen_country_message', prekini izvršavanje
+
+    // Funkcija za prikazivanje bannera za zemlju
+	function showCountryBanner2(banner) {
+        banner.children[0].innerHTML = 'Show banner';
+        banner.children[1].innerHTML = '';
+        banner.children[0].onclick = function(e) {
+			showCountryBanner1(banner)
+        }
+    }
+	
+	function showCountryBanner1(banner) {
+        banner.children[0].innerHTML = 'Hide banner';
+        banner.children[1].innerHTML = 'This site is for reporting <strong>problems in Croatia</strong>. The original <a href="https://www.fixmystreet.com/">site</a> is <strong>in the UK</strong>. There are FixMyStreet sites <a href="https://fixmystreet.org/sites/">all over the world</a>, or you could set up your own using the <a href="https://fixmystreet.org/">FixMyStreet Platform</a>.';
+		
+        banner.children[0].onclick = function(e) {
+			showCountryBanner2(banner)
+        }
+    }
+	
+	function buildCountryBanner() {
+        var banner = document.createElement('div');
+        banner.className = 'top_banner top_banner--country';
+        
+        var close = document.createElement('a');
+        close.className = 'top_banner__close';
+        close.innerHTML = 'Hide banner';
+        close.href = '#';
+        close.onclick = function(e) {
+			showCountryBanner2(banner)
+			//banner.style.display = 'none'; // Sakrij banner
+            //var t = new Date(); 
+            //t.setFullYear(t.getFullYear() + 1);
+            //document.cookie = 'has_seen_country_message=1; path=/; expires=' + t.toUTCString();
+        };
+
+        var p = document.createElement('p');
+        p.innerHTML = 'This site is for reporting <strong>problems in Croatia</strong>. The original <a href="https://www.fixmystreet.com/">site</a> is <strong>in the UK</strong>. There are FixMyStreet sites <a href="https://fixmystreet.org/sites/">all over the world</a>, or you could set up your own using the <a href="https://fixmystreet.org/">FixMyStreet Platform</a>.';
+
+        banner.appendChild(close);
+        banner.appendChild(p);
+        document.body.insertBefore(banner, document.body.firstChild);
+
+        // Prikaži banner
+        banner.style.display = 'block';
+    }
+
+    // AJAX zahtjev za dobivanje informacija o zemlji
+	/* Front page banner for other countries */
+    var request = new XMLHttpRequest();
+    request.open('GET', 'https://gaze.mysociety.org/gaze-rest?f=get_country_from_ip', true);
+    request.onreadystatechange = function() {
+        if (this.readyState === 4) {
+            if (this.status >= 200 && this.status < 400) {
+                var data = this.responseText;
+                if ( data && data.trim() === 'HR' ) { // Provjeri je li kod zemlje 'HR'
+                    buildCountryBanner();
+                }
+            }
+        }
+    };
+    request.send();
+	request = null;
+	
+})();

--- a/web/cobrands/popravitodev/layout.scss
+++ b/web/cobrands/popravitodev/layout.scss
@@ -6,10 +6,21 @@ $body-font: 'Open Sans';
 $headings-font: 'Darker Grotesque';
 $primary: url('/cobrands/#{$cobrand-moniker}/images/hero-desktop.svg') no-repeat right;
 
+.top_banner {
+text-align: right;
+}
+.top_banner p {
+text-align: center;
+}
+.top_banner a {
+text-decoration: underline;
+}
+
 /* header */
 
 .header {
 display: flex;
+justify-content: space-between;
 align-items: center;
 padding: 1.3rem 0 1.3rem 0;
 position: inherit;
@@ -34,7 +45,7 @@ margin: 0 auto;
 
 .menu {
 display: flex;
-position: absolute;
+position: relative;
 right: 7.5rem;
 padding: 0;
 background-color: transparent;
@@ -43,11 +54,11 @@ height: auto;
 /* margin-top: 0; */
 
     @media only screen and (min-width: 850px) and (max-width: 1010px){
-right: 1rem;
+right: 5rem;
 }
 
     @media only screen and (min-width: 769px) and (max-width: 849px){
-right: -7rem;
+right: 2.5rem;
 }
 }
 
@@ -90,7 +101,7 @@ max-width: 100%;
 
 .central-content {
 background: $primary;
-padding: 8.5rem 5.5rem 8.5rem 5.5rem;
+padding: 5rem 5.5rem 5rem 5.5rem;
 }
 
 .search {


### PR DESCRIPTION
Created front.js file, updated index.html and layout.scss files.
Changes made will be recorded in the Pull Request description of the original popravi.to repository. Likewise, they will be recorded in the commit comment of the forked popravi.to repository.
This commit contains also the changes made by the 44b96ec commit which are not as of yet pulled into the original popravi.to repository.
This addresses issue #34.

This issue was worked on together by next GitHub users
@MihajloVSc
@jerkdavi

# changes:
### created file front.js
- updated file front.js to contain functions for creating and showing two different versions of 'top_banner' div
- the idea was to be able to hide and show back the banner on click
- the fixmystreet.com site has exclusively the option the close the banner
---
### updated index.html
- added a script reference to file front.js
---
### updated layout.scss
- in header class, added justify-content - space-between line
- in menu class, updated position from absolute to relative
- for menu class media, right values updated from 1, -7 to 5, 2.5 respectively
- created top_banner class, and text-aligned - right
- created top_banner p, and text-aligned - center
- created top_banner a, and added text-decoration - underline
---