### PR TITLE
Add responsive padding for .central-content

### DIFF
--- a/web/cobrands/popravitodev/layout.scss
+++ b/web/cobrands/popravitodev/layout.scss
@@ -92,6 +92,10 @@ max-width: 100%;
 background: $primary;
   padding: 5rem 5.5rem 5rem 5.5rem;
 
+  @media (max-width: 768px) {
+    padding: 3rem 1.5rem 3rem 1.5rem;
+  }
+
 }
 
 .search {


### PR DESCRIPTION
Follow-up to PR #196 - adds responsive padding for mobile viewports.

Addresses review suggestion: 80px vertical padding may be too large for mobile devices.

Closes #196 (continuation)